### PR TITLE
[Feature]: Create scripts from the terminal

### DIFF
--- a/scripts/dotly/create
+++ b/scripts/dotly/create
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+
+. "$DOTLY_PATH/scripts/core/_main.sh"
+. "$DOTLY_PATH/scripts/core/templating.sh"
+
+SCRIPT_NAME="dot dotly create"
+SCRIPT_VERSION="1.0.0"
+SCRIPT_TEMPLATE="$DOTLY_PATH/scripts/dotly/helpers/script-template"
+
+##? Dotly script creator
+##? 
+##?
+##? Usage:
+##?   create [-h | --help]
+##?   create [-v | --version]
+##?   create [-c | --core] [-s | --sample] <context> <script_name> [<script_description>...]
+##?
+##? Options:
+##?   -h --help     Show this help
+##?   -v --version  Show the program version
+##?   -s --sample   Create a script using more complete example with some comments.
+##?                 useful if it is your first script. Anyway you can see more help
+##?                 in the docopt website: http://docopt.org
+##?   -c --core     Create the context and script in "$DOTLY_PATH/scripts" instead of
+##?                 your "$DOTFILES_PATH/scripts" folder
+##?
+##? Author:
+##?   Gabriel Trabanco <https://keybase.io/gtrabanco>
+##?
+docs::parse "$@"
+
+# Print name and version
+if ${version:-}; then
+  output::write "$SCRIPT_NAME v$SCRIPT_VERSION"
+  exit
+fi
+
+if [[ -z "${context:-}" ]] || [[ -z "${script_name:-}" ]]; then
+  output::error "You should provide a context and script name"
+  output::write "Use: $0 -h"
+  exit 1
+fi
+
+# Path variables
+if ${core:-}; then
+  output::empty_line
+  output::write "\033[0;31m\033[1m  ALERT!!!!!"
+  output::write "Create this script in your DOTLY scripts folder could be very dangerous."
+  output::write "This is an option thinked only for DOTLY devs.\033[0m"
+  output::empty_line
+  output::yesno "Are you sure you still want to coninue" "N" || { output::answer "User aborted" && exit 1; }
+
+  script_path="$DOTLY_PATH/scripts/$context"
+else
+  script_path="$DOTFILES_PATH/scripts/$context"
+fi
+
+script_filepath="$script_path/$script_name"
+
+# Which template to use
+if ${sample:-}; then
+  SCRIPT_TEMPLATE="$SCRIPT_TEMPLATE-more"
+fi
+
+# Create the script context (folder)
+mkdir -p "$script_path"
+
+if [[ -d "$DOTFILES_PATH/scripts/$context" ]]; then
+  output::solution "$script_path were created or exists previously"
+fi
+
+# If script exits ask user to overwrite
+if [[ -f $script_filepath ]]; then
+  output::yesno "The script exists, do you want to delete it and create a empty script" "N" ||\
+    {
+      output::error "The script name \"$script_name\" exists in context \"$context\" and user refuse to recreate the script" &&\
+      output::write "Provide a different name for the script or context." &&\
+      exit 1
+    }
+fi
+
+# Variables for the script
+author="$(git config --global --get user.name)"
+email="$(git config --global --get user.email)"
+description="${script_description[*]:-}"
+
+# Description can not be empty
+[[ -z "$description" ]] && output::question "Description can not be empty, describe your script" "description"
+
+cp "$SCRIPT_TEMPLATE" "$script_filepath"
+templating::replace "$script_filepath" --script-name="$script_name" --script-context="$context" --script-author="$author" --script-author-email="$email" --script-description="$description" > /dev/null
+chmod u+x "$script_filepath"
+
+output::empty_line
+output::solution "The script '$script_name' where successfully created."
+output::write ""
+output::write "You can access the scipt with your favorite editor by executing:"
+output::write "\$EDITOR \"\$DOTFILES_PATH/scripts/$context/$script_name\""
+output::empty_line

--- a/scripts/dotly/helpers/script-template
+++ b/scripts/dotly/helpers/script-template
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+[[ -z "$DOTLY_PATH" ]] && exit 1
+
+. "$DOTLY_PATH/scripts/core/_main.sh"
+
+##? XXX_SCRIPT_DESCRIPTION_XXX
+##? 
+##?
+##? Usage:
+##?   XXX_SCRIPT_NAME_XXX [-h | --help]
+##?   XXX_SCRIPT_NAME_XXX [-v | --version]
+##?
+##? Options:
+##?   -h --help     Show this help
+##?   -v --version  Show the program version
+##?
+##? Author:
+##?   XXX_SCRIPT_AUTHOR_XXX <XXX_SCRIPT_AUTHOR_EMAIL_XXX>
+docs::parse "$@"
+
+SCRIPT_NAME="dot XXX_SCRIPT_CONTEXT_XXX XXX_SCRIPT_NAME_XXX"
+SCRIPT_VERSION="1.0.0"
+
+# Print name and version
+if ${version:-}; then
+  output::write "$SCRIPT_NAME v$SCRIPT_VERSION"
+  exit
+fi
+
+# Here begin your script
+
+case $1 in
+# Any subcommand should be here
+*)
+  exit 1
+  ;;
+esac

--- a/scripts/dotly/helpers/script-template-more
+++ b/scripts/dotly/helpers/script-template-more
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+[[ -z "$DOTLY_PATH" ]] && exit 1
+
+. "$DOTLY_PATH/scripts/core/_main.sh"
+
+##? XXX_SCRIPT_DESCRIPTION_XXX
+##? 
+##?
+##? Usage:
+##?   XXX_SCRIPT_NAME_XXX [-h | --help]
+##?   XXX_SCRIPT_NAME_XXX [-v | --version]
+##?   XXX_SCRIPT_NAME_XXX -c | --custom-option
+##?   XXX_SCRIPT_NAME_XXX subcommand <example_variable> [<example_optional_variable>...]
+##?
+##? Options:
+##?   -h --help                                                      Show this help
+##?   -v --version                                                   Show the program version
+##?   -c --custom-option                                             With two or more spaces you can add some help
+##?   subcomand <example_variable> [<example_optional_variable>...]  Also provide a help with subcommand
+##? This text will be printed as well when you call -h or --help option
+##?
+##? Author:
+##?   XXX_SCRIPT_AUTHOR_XXX <XXX_SCRIPT_AUTHOR_EMAIL_XXX>
+
+# Options part its important because assign short and long version of the params
+docs::parse "$@"
+
+SCRIPT_NAME="dot XXX_SCRIPT_CONTEXT_XXX XXX_SCRIPT_NAME_XXX"
+SCRIPT_VERSION="1.0.0"
+
+# Print name and version
+if ${version:-}; then
+  output::write "$SCRIPT_NAME v$SCRIPT_VERSION"
+  exit
+fi
+
+# Here begin your script
+
+case $1 in
+"subcommand")
+  echo "This case is optional and only useful if you want to implement subcommands"
+  echo "The example repeteable variable value is \"${example_variable[*]:-No value provided}\""
+  echo "The optional variable value is \"${example_optional_variable:-No value provided}\""
+  ;;
+*)
+  exit 1
+  ;;
+esac

--- a/scripts/dotly/install-remote
+++ b/scripts/dotly/install-remote
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+
+source "$DOTLY_PATH/scripts/core/_main.sh"
+
+SCRIPT_NAME="dot dotly install-remote"
+SCRIPT_VERSION="1.0.0"
+
+# Save current working directory to return user there
+STARTING_DIRECTORY="$(pwd)"
+CURL_BIN="$(which curl)"
+
+##? Install remote context or script in your $DOTFILES_PATH from url. It
+##? must be the url to the raw file.
+##? If you fill the last param <script_name>, the remote file name will be
+##? omited and renamed in your $DOTFILES_PATH/scripts/<context> folder
+##?
+##? Usage:
+##?   install-remote [ -h | --help ]
+##?   install-remote [ -v | --version ]
+##?   install-remote <context> <script_raw_url> [<script_name>]
+##?
+##? Options:
+##?   -h --help     Show this help
+##?   -v --version  Show the program version
+##?
+##?
+##? Author:
+##?   Gabriel Trabanco Llano <gtrabanco@users.noreply.github.com>
+docs::parse "$@"
+
+# Print name and version
+if $version; then
+  output::write "$SCRIPT_NAME v$SCRIPT_VERSION"
+  exit
+fi
+
+# Script name if provided if not with downloaded name
+[[ -n $script_name ]] && script_name_args="-o $script_name" || script_name_args=${script_name:-"-O"}
+
+# Download command
+download_command="$CURL_BIN -k -L -f -q $script_name_args"
+
+# Scripts context directory
+dotfiles_context="$DOTFILES_PATH/scripts/$context"
+
+# Create context directory and move to it
+mkdir -p "$dotfiles_context"
+cd "$dotfiles_context"
+
+# Download the script
+output::write "Downloading the script ⚡️"
+$(echo "$download_command" "$script_raw_url")
+if [ ! $? ] ; then
+  if [ ! $(ls -A "$dotfiles_context") ]; then
+    output::answer "El context $dotfiles_context esta vacio"
+  fi
+fi
+
+# Getting the name
+script_name="$(ls -Art | tail -n 1)"
+
+# Applying execution rights
+chmod u+x "$dotfiles_context/$script_name"
+
+# How to use it :)
+echo
+output::solution "The script was successfully added 😀"
+output::write "You can execute the script now with:"
+output::write "dot $context $script_name"
+
+cd "$STARTING_DIRECTORY"


### PR DESCRIPTION
# Requirements
* PR #119 

# Features
* Add command `dot dotly create <context> <script_name>` to create scripts with chmod and all stuff directly from terminal. See `dot dotly create --help` because there are some interesting options.
* Add command `dot dotly install-remote <context> <script_raw_url> [<script_name>]`. With this command you can install a remote script directly in the given context and (if provided) the script name you want (it takes filename by default; sometimes could happend that this gives an error which it would be solved by adding manually a the script name).

# Motivation
Makes easier and faster the way to create new commands for dotly. Was tedious for me add manually the script with always the same structure.

# Future upgrades
Added the same templating for TS scripts for dotly when PR will be merged.